### PR TITLE
fix: generate valid system.prop entries from getprop output

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -414,9 +414,10 @@ if [ -n "$FLAGS_ACTIVE" ]; then
     getprop | grep "test-keys" >> "$TMP_PROP"
     getprop | grep "lineage_" >> "$TMP_PROP"
 
-    # Basic cleanup
+    # Convert Android getprop output from "[key]: [value]" to the
+    # key=value syntax required by system.prop loaders.
     sed -i 's///g' "$TMP_PROP"
-    sed -i 's/: /=/g' "$TMP_PROP"
+    sed -i -E 's/^\[([^]]+)\]: \[(.*)\]$/\1=\2/' "$TMP_PROP"
 else
     note "No prop sanitization flags found. Skipping."
 fi


### PR DESCRIPTION
Android getprop emits properties as [key]: [value]. The current replacement changes only the separator, producing [key]=[value], which is not valid system.prop syntax. KernelSU consequently reports that loading the module system.prop failed.

This change converts the complete getprop record to key=value while preserving values containing spaces or colons.

Validated with representative getprop output, bash syntax checking, git diff checking, and a real KernelSU Next/Waydroid boot. Before the change the boot log contained load system.prop failed; after the change KernelSU loaded the file successfully.